### PR TITLE
Bug: Fixes recall issue for presets above 128

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -219,7 +219,7 @@ export function getActions() {
 		name: 'Recall Preset',
 		options: this.listOptions('Preset', PRESET_COUNT, -1),
 		callback: (action) => {
-			let presetNumber = parseInt(action.options.number)
+			let presetNumber = parseInt(action.options.number) % 128
 			let buffers = [
 				Buffer.from([
 					0xb0,


### PR DESCRIPTION
This PR fixes a preset recall bug mentioned in #51 . The preset number needs to be divided without remainder to make it fit on the recall number table, then converted to hex.

Marking as draft because I'm unable to test this at the moment. I've been building a plugin interfacing AHM with a different system, and now I can no longer connect to it with Companion. I did just update to 4.3; maybe that's causing the problem.