### PR TITLE
Fix: revert to api 2.0 from 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"url": "git+https://github.com/bitfocus/companion-module-allenheath-ahm.git"
 	},
 	"dependencies": {
-		"@companion-module/base": "~2.1.0"
+		"@companion-module/base": "~2.0.0"
 	},
 	"devDependencies": {
 		"@companion-module/tools": "~3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,13 @@
 # yarn lockfile v1
 
 
-"@companion-module/base@~2.1.0":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@companion-module/base/-/base-2.1.2.tgz#21ee374eee50840654eeba2beb46ad73e0a99e15"
-  integrity sha512-L5Nm771r24JMfaZPONOoBqnXf0gWAOMjHqIf3C6gVp5qpxalAlSZLfEaGn+VNOEVgncKYG1yKDTp407qaiFeLQ==
+"@companion-module/base@~2.0.0":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@companion-module/base/-/base-2.0.4.tgz#af9a7d89ee9f5866d1090c1672943ec454672356"
+  integrity sha512-OoPd8SexxrZwyE3B9hIpMb5psqIOnD49dsQCyJ8MMrDmNSyvDthmPJKQF2Gn4zmf+0wnnh/OyxVEryJ53P6dQA==
   dependencies:
     colord "^2.9.3"
+    tslib "^2.8.1"
 
 "@companion-module/tools@~3.0.0":
   version "3.0.2"
@@ -415,6 +416,11 @@ tar@^7.5.16:
     minipass "^7.1.2"
     minizlib "^3.1.0"
     yallist "^5.0.0"
+
+tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 unicorn-magic@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Upgrade from API 2.0 to 2.1 was accidental, and made module incompatible with Companion 4.3.x. Reverting.