### PR TITLE
Add live-state toggle option to mute actions

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -8,6 +8,12 @@ Use the IP of your AHM unit from the AHM System Manager software or your network
 
 This module routinely requests channel data from the AHM every so often in order to keep Companion's variables up to date with other controllers connected to the AHM. Raise the refresh rate value to cut down on network traffic (10,000 ms = 10 sec). This module will request current levels and mutes outside of this interval if the user recalls a preset, or changes a level or mute of a channel.
 
+## Toggle Mute
+
+The input, zone, control group, and input-to-zone mute actions include an **Operation** choice. Select **Set mute state** to explicitly mute or unmute, or select **Toggle current state** to invert the live value reported by the AHM.
+
+Toggle mode requests the current mute value before sending the opposite state. If the AHM does not answer within one second, the module logs an error and does not send a potentially incorrect mute command.
+
 ## Upgrade Notice
 
 Users upgrading from the `2.x` module version should fill out the Manual Channel Tracking section on the connection configuration page with input, zone, and control group numbers they need global variables created for. In order to save startup time, this module no longer creates global variables for the level of every input, zone, and control group.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"format": "prettier -w .",
 		"package": "companion-module-build",
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "node --test tests/*.test.js"
 	},
 	"license": "MIT",
 	"repository": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,6 @@
 import { getChoicesArrayOf1DArray, getChoicesArrayOfKeyValueObject } from './utility/helpers.js'
 import { ChannelType, SendType, SendInfoType, dbu_Values, PlaybackChannel } from './utility/constants.js'
-import { setMute, setLevel, adjustLevel, requestLevelInfo } from './formatMIDI/channels.js'
+import { setMute, setLevel, adjustLevel, requestLevelInfo, requestMuteInfo } from './formatMIDI/channels.js'
 import { requestSendInfo, adjustSendLevel, setInputToZoneMute } from './formatMIDI/sends.js'
 import { setPlaybackTrack } from './formatMIDI/playback.js'
 import { recallPreset } from './formatMIDI/presets.js'
@@ -11,6 +11,12 @@ import { createLogger } from './utility/log.js'
 const PRESET_COUNT = 500
 const PLAYBACK_COUNT = 127
 const log = createLogger('Actions')
+const MUTE_STATE_TIMEOUT_MS = 1000
+
+const MuteOperation = {
+	Set: 'set',
+	Toggle: 'toggle',
+}
 
 export const ActionId = {
 	MuteInput: 'mute_input',
@@ -58,6 +64,7 @@ function listOptions(label, max) {
 /**
  * Builds Companion Action Options for mute actions.
  * Id of the number field will be 'mute_number'.
+ * Id of the operation dropdown will be 'operation'.
  * Id of the mute checkbox field will be 'mute'.
  * @param {String} label - The label of the number field
  * @param {Number} max - maximum value of the number input
@@ -76,9 +83,20 @@ function muteOptions(label, max) {
 			clampValues: false, // would change values when switching AHM types
 		},
 		{
+			type: 'dropdown',
+			id: 'operation',
+			label: 'Operation',
+			default: MuteOperation.Set,
+			choices: [
+				{ id: MuteOperation.Set, label: 'Set mute state' },
+				{ id: MuteOperation.Toggle, label: 'Toggle current state' },
+			],
+		},
+		{
 			type: 'checkbox',
 			id: 'mute',
 			label: 'Mute',
+			isVisible: (options) => options.operation !== MuteOperation.Toggle,
 			default: true,
 		},
 	]
@@ -165,6 +183,29 @@ function playbackChannelOptions(label) {
 	]
 }
 
+async function resolveMute(action, requestCurrentMute, target) {
+	if (action.options.operation !== MuteOperation.Toggle) return action.options.mute
+
+	try {
+		return !(await requestCurrentMute())
+	} catch (error) {
+		log.error('ToggleMuteFailed', { target, message: error.message ?? error })
+		return undefined
+	}
+}
+
+function requestCurrentChannelMute(state, tcpClient, type, chNumber) {
+	const pendingMute = state.waitForChannelMute(type, chNumber, MUTE_STATE_TIMEOUT_MS)
+	tcpClient.queue(requestMuteInfo(type, chNumber))
+	return pendingMute
+}
+
+function requestCurrentSendMute(state, tcpClient, inputNum, zoneNum) {
+	const pendingMute = state.waitForSendMute(ChannelType.Input, inputNum, zoneNum, MUTE_STATE_TIMEOUT_MS)
+	tcpClient.queue(requestSendInfo(SendType.InputToZone, SendInfoType.MUTE, inputNum, zoneNum))
+	return pendingMute
+}
+
 export function getActions(numberOfInputs, numberOfZones, numberOfControlGroups) {
 	const { companion, state, tcpClient } = getContext()
 	let actions = {}
@@ -175,10 +216,15 @@ export function getActions(numberOfInputs, numberOfZones, numberOfControlGroups)
 		name: 'Mute Input',
 		options: muteOptions('Input', numberOfInputs),
 		callback: async (action) => {
-			let inputNum = action.options.mute_number
-			let mute = action.options.mute
+			const inputNum = action.options.mute_number
+			const mute = await resolveMute(
+				action,
+				() => requestCurrentChannelMute(state, tcpClient, ChannelType.Input, inputNum),
+				`input ${inputNum}`,
+			)
+			if (mute === undefined) return
 
-			log.debug(ActionId.MuteInput, { inputNum, mute })
+			log.debug(ActionId.MuteInput, { inputNum, mute, operation: action.options.operation ?? MuteOperation.Set })
 			tcpClient.queue(setMute(ChannelType.Input, inputNum, mute))
 
 			state.setChannel(ChannelType.Input, inputNum, undefined, mute)
@@ -189,11 +235,16 @@ export function getActions(numberOfInputs, numberOfZones, numberOfControlGroups)
 	actions[ActionId.MuteZone] = {
 		name: 'Mute Zone',
 		options: muteOptions('Zone', numberOfZones),
-		callback: (action) => {
-			let zoneNum = action.options.mute_number
-			let mute = action.options.mute
+		callback: async (action) => {
+			const zoneNum = action.options.mute_number
+			const mute = await resolveMute(
+				action,
+				() => requestCurrentChannelMute(state, tcpClient, ChannelType.Zone, zoneNum),
+				`zone ${zoneNum}`,
+			)
+			if (mute === undefined) return
 
-			log.debug(ActionId.MuteZone, { zoneNum, mute })
+			log.debug(ActionId.MuteZone, { zoneNum, mute, operation: action.options.operation ?? MuteOperation.Set })
 			tcpClient.queue(setMute(ChannelType.Zone, zoneNum, mute))
 
 			state.setChannel(ChannelType.Zone, zoneNum, undefined, mute)
@@ -205,10 +256,19 @@ export function getActions(numberOfInputs, numberOfZones, numberOfControlGroups)
 		name: 'Mute Control Group',
 		options: muteOptions('Control Group', numberOfControlGroups),
 		callback: async (action) => {
-			let cgNum = action.options.mute_number
-			let mute = action.options.mute
+			const cgNum = action.options.mute_number
+			const mute = await resolveMute(
+				action,
+				() => requestCurrentChannelMute(state, tcpClient, ChannelType.ControlGroup, cgNum),
+				`control group ${cgNum}`,
+			)
+			if (mute === undefined) return
 
-			log.debug(ActionId.MuteControlGroup, { cgNum, mute })
+			log.debug(ActionId.MuteControlGroup, {
+				cgNum,
+				mute,
+				operation: action.options.operation ?? MuteOperation.Set,
+			})
 			tcpClient.queue(setMute(ChannelType.ControlGroup, cgNum, mute))
 
 			state.setChannel(ChannelType.ControlGroup, cgNum, undefined, mute)
@@ -219,15 +279,27 @@ export function getActions(numberOfInputs, numberOfZones, numberOfControlGroups)
 	actions[ActionId.MuteInputToZone] = {
 		name: 'Mute Input to Zone',
 		options: muteOptions('Input', numberOfInputs).concat(listOptions('Zone', numberOfZones)),
-		callback: (action) => {
-			let inputNum = action.options.mute_number
-			let zoneNum = action.options.number
+		callback: async (action) => {
+			const inputNum = action.options.mute_number
+			const zoneNum = action.options.number
+			const mute = await resolveMute(
+				action,
+				() => requestCurrentSendMute(state, tcpClient, inputNum, zoneNum),
+				`input ${inputNum} to zone ${zoneNum}`,
+			)
+			if (mute === undefined) return
 
-			log.debug(ActionId.MuteInputToZone, { inputNum, zoneNum, infoType: SendInfoType.MUTE })
-			tcpClient.queue(setInputToZoneMute(inputNum, zoneNum, action.options.mute))
+			log.debug(ActionId.MuteInputToZone, {
+				inputNum,
+				zoneNum,
+				mute,
+				operation: action.options.operation ?? MuteOperation.Set,
+				infoType: SendInfoType.MUTE,
+			})
+			tcpClient.queue(setInputToZoneMute(inputNum, zoneNum, mute))
 
 			// manually update internal state
-			state.setSend(ChannelType.Input, inputNum, zoneNum, undefined, action.options.mute)
+			state.setSend(ChannelType.Input, inputNum, zoneNum, undefined, mute)
 			companion.checkFeedbacks(FeedbackId.InputToZoneMute)
 
 			setTimeout(() => {

--- a/src/state/tracking.js
+++ b/src/state/tracking.js
@@ -16,6 +16,47 @@ const log = createLogger('Tracking')
  * visible alongside its current values.
  */
 export function createTracking(state) {
+	const channelMuteWaiters = new Map()
+	const sendMuteWaiters = new Map()
+
+	function createMuteWaiter(waiters, key, timeoutMs) {
+		return new Promise((resolve, reject) => {
+			const waiter = { resolve, timeout: null }
+			waiter.timeout = setTimeout(() => {
+				const pending = waiters.get(key)
+				pending?.delete(waiter)
+				if (pending?.size === 0) waiters.delete(key)
+				reject(new Error('Timed out waiting for mute state'))
+			}, timeoutMs)
+
+			let pending = waiters.get(key)
+			if (!pending) {
+				pending = new Set()
+				waiters.set(key, pending)
+			}
+			pending.add(waiter)
+		})
+	}
+
+	function resolveMuteWaiters(waiters, key, mute) {
+		const pending = waiters.get(key)
+		if (!pending) return
+
+		waiters.delete(key)
+		for (const waiter of pending) {
+			clearTimeout(waiter.timeout)
+			waiter.resolve(mute)
+		}
+	}
+
+	function channelMuteKey(type, chNumber) {
+		return `${type}:${chNumber}`
+	}
+
+	function sendMuteKey(type, fromChNum, toChNum) {
+		return `${type}:${fromChNum}:${toChNum}`
+	}
+
 	/**
 	 * Create an empty channel state without adding a subscription.
 	 * @returns {Object} Newly initialized channel state
@@ -120,7 +161,23 @@ export function createTracking(state) {
 		const channel = state.trackedChannels[type]?.get(chNumber)
 		if (!channel) return
 		if (level !== undefined) channel.level = level
-		if (mute !== undefined) channel.mute = mute
+		if (mute !== undefined) {
+			channel.mute = mute
+			resolveMuteWaiters(channelMuteWaiters, channelMuteKey(type, chNumber), mute)
+		}
+	}
+
+	/**
+	 * Wait for the next mute response for a channel.
+	 * Manual tracking keeps the channel available for later toggle actions and polling.
+	 * @param {ChannelType} type - ChannelType
+	 * @param {Number} chNumber - Channel number (1-indexed)
+	 * @param {Number} timeoutMs - Maximum wait time
+	 * @returns {Promise<Boolean>} The mute value from the next AHM response
+	 */
+	function waitForChannelMute(type, chNumber, timeoutMs = 1000) {
+		addChannel(type, chNumber, MANUAL_ID, MANUAL_ID)
+		return createMuteWaiter(channelMuteWaiters, channelMuteKey(type, chNumber), timeoutMs)
 	}
 
 	/**
@@ -242,8 +299,25 @@ export function createTracking(state) {
 		const send = state.trackedChannels[type]?.get(fromChNum)?.sends.get(toChNum)
 		if (!send) return
 		if (level !== undefined) send.level = level
-		if (mute !== undefined) send.mute = mute
+		if (mute !== undefined) {
+			send.mute = mute
+			resolveMuteWaiters(sendMuteWaiters, sendMuteKey(type, fromChNum, toChNum), mute)
+		}
 		send.initialized = true // future addSend calls will return isNew=false
+	}
+
+	/**
+	 * Wait for the next mute response for a send.
+	 * Manual tracking keeps the send available for later toggle actions and polling.
+	 * @param {ChannelType} type - Type of the source channel
+	 * @param {Number} fromChNum - Source channel number (1-indexed)
+	 * @param {Number} toChNum - Target channel number (1-indexed)
+	 * @param {Number} timeoutMs - Maximum wait time
+	 * @returns {Promise<Boolean>} The mute value from the next AHM response
+	 */
+	function waitForSendMute(type, fromChNum, toChNum, timeoutMs = 1000) {
+		addSend(type, fromChNum, toChNum, MANUAL_ID, MANUAL_ID)
+		return createMuteWaiter(sendMuteWaiters, sendMuteKey(type, fromChNum, toChNum), timeoutMs)
 	}
 
 	/**
@@ -337,12 +411,14 @@ export function createTracking(state) {
 		addChannel,
 		removeChannel,
 		setChannel,
+		waitForChannelMute,
 		getTrackedChannelMap,
 		getLevel,
 		getMute,
 		addSend,
 		removeSend,
 		setSend,
+		waitForSendMute,
 		getTrackedSends,
 		getSendLevel,
 		getSendMute,

--- a/tests/actions.test.js
+++ b/tests/actions.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getActions, ActionId } from '../src/actions.js'
+import { initContext } from '../src/context.js'
+import { requestMuteInfo, setMute } from '../src/formatMIDI/channels.js'
+import { trackAHMParams } from '../src/state/AHMState.js'
+import { ChannelType } from '../src/utility/constants.js'
+
+function createHarness() {
+	const queued = []
+	const checkedFeedbacks = []
+	const logs = []
+	const state = trackAHMParams()
+
+	initContext({
+		state,
+		tcpClient: {
+			queue: (command) => queued.push(command),
+		},
+		companion: {
+			checkFeedbacks: (...feedbacks) => checkedFeedbacks.push(feedbacks),
+			log: (level, message) => logs.push({ level, message }),
+		},
+		poller: null,
+	})
+
+	return {
+		actions: getActions(16, 16, 32),
+		checkedFeedbacks,
+		logs,
+		queued,
+		state,
+	}
+}
+
+test('mute actions expose set and toggle operations', () => {
+	const { actions } = createHarness()
+	for (const actionId of [ActionId.MuteInput, ActionId.MuteZone, ActionId.MuteControlGroup, ActionId.MuteInputToZone]) {
+		const operation = actions[actionId].options.find((option) => option.id === 'operation')
+		assert.equal(operation.default, 'set')
+		assert.deepEqual(
+			operation.choices.map((choice) => choice.id),
+			['set', 'toggle'],
+		)
+	}
+})
+
+test('legacy mute actions without an operation still set the requested state', async () => {
+	const { actions, queued } = createHarness()
+
+	await actions[ActionId.MuteInput].callback({ options: { mute_number: 2, mute: false } })
+
+	assert.equal(queued.length, 1)
+	assert.deepEqual(queued[0], setMute(ChannelType.Input, 2, false))
+})
+
+test('toggle requests the live channel state and sends its inverse', async () => {
+	const { actions, queued, state } = createHarness()
+
+	const action = actions[ActionId.MuteInput].callback({
+		options: { mute_number: 3, operation: 'toggle', mute: true },
+	})
+
+	assert.deepEqual(queued[0], requestMuteInfo(ChannelType.Input, 3))
+	state.setChannel(ChannelType.Input, 3, undefined, true)
+	await action
+
+	assert.equal(queued.length, 2)
+	assert.deepEqual(queued[1], setMute(ChannelType.Input, 3, false))
+	assert.equal(state.getMute(ChannelType.Input, 3), false)
+})
+
+test('send mute waiters resolve from a tracked input-to-zone response', async () => {
+	const { state } = createHarness()
+	const pending = state.waitForSendMute(ChannelType.Input, 4, 5, 100)
+
+	state.setSend(ChannelType.Input, 4, 5, undefined, true)
+
+	assert.equal(await pending, true)
+	assert.equal(state.getSendMute(ChannelType.Input, 4, 5), true)
+})


### PR DESCRIPTION
Closes #29

## What changed

- Adds an **Operation** selector to input, zone, control-group, and input-to-zone mute actions.
- Preserves existing explicit mute/unmute behavior as the default.
- In toggle mode, requests the current mute value from the AHM and sends the inverse.
- Avoids sending a guessed state when the device does not respond within one second.
- Adds focused tests and user-facing documentation.

## Why

Users currently need multiple actions, Action Logic, or workflow variables to toggle mute. A native toggle keeps the action compact while using the processor live state as the source of truth.

## Validation

- `yarn test` — 4 tests passing
- `yarn package` — module package builds successfully